### PR TITLE
fix: ensure exit code of tests are returned from container

### DIFF
--- a/src/main/resources/init/entrypoint.sh
+++ b/src/main/resources/init/entrypoint.sh
@@ -17,5 +17,3 @@ mvn verify -q -B -Darazzo.file="$ARAZZO_FILE" -Darazzo-inputs.file="$ARAZZO_INPU
 # force report generation in any case
 echo "Reports will be generated."
 mvn failsafe:verify -q -B
-
-echo "==============="


### PR DESCRIPTION
nice work on the library, I've been giving it a quick spin.

I noted that we suppress the exit code of the test run, as it isn't saved, and propagated, after the subsequent echo.

If you wish to retain the echo statement, you will want to grab the exit code and return it as the last thing in the script.